### PR TITLE
Generalize type of expression parser

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,15 @@
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "default" }:
+
+let
+
+  inherit (nixpkgs) pkgs;
+
+  haskellPackages = if compiler == "default"
+                       then pkgs.haskellPackages
+                       else pkgs.haskell.packages.${compiler};
+
+  drv = haskellPackages.callPackage ./. {};
+
+in
+
+  if pkgs.lib.inNixShell then drv.env else drv


### PR DESCRIPTION
The parser is generalized to 
```
Dhall.Parser.expr :: Show a => Parser a -> Parser (Expr Src a)
```
Originally, I wanted to do this to allow _literal_ paths for my own project, i.e. file-relative paths that would _not_ be imported. Then I realized this would also be a convenient way for an application to extend the language with their own builtin functions or keywords.