### PR TITLE
Add support for customizing derived `auto` implementation.  Fixes #22

### DIFF
--- a/src/Dhall.hs
+++ b/src/Dhall.hs
@@ -32,6 +32,7 @@ module Dhall
     , text
     , maybe
     , vector
+    , GenericInterpret(..)
 
     -- * Re-exports
     , Natural
@@ -443,6 +444,9 @@ defaultInterpretOptions = InterpretOptions
     , constructorModifier = id
     }
 
+{-| This is the underlying class that powers the `Interpret` class's support
+    for automatically deriving a generic implementation
+-}
 class GenericInterpret f where
     genericAuto :: InterpretOptions -> Type (f a)
 


### PR DESCRIPTION
This adds a new `deriveAuto` utility that you can customize with
`InterpretOptions` in order to transform the expected field or constructor
labels that Dhall expects

The most common use of this is to support data types that prefix field names
with underscores for lens support