### PR TITLE
Add support for importing paths as raw `Text`

### DIFF
--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -132,7 +132,7 @@ instance Buildable Path where
     build (Path {..}) = build pathType <> suffix
       where
         suffix = case pathMode of
-            RawText -> " as Text"
+            RawText -> "as Text"
             Code    -> ""
 
 {-| Label for a bound variable


### PR DESCRIPTION
Part of #23

You can now add ` as Text` to the end of any path and the raw contents at that
path will be imported as a raw `Text` literal.  For example:

```
$ dhall <<< "http://example.com as Text"
Text

"<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n    <meta
 charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html
; charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width,
initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        backgro
und-color: #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-famil
y: \"Open Sans\", \"Helvetica Neue\", Helvetica, Arial, sans-serif;\n        \n
   }\n    div {\n        width: 600px;\n        margin: 5em auto;\n        paddi
ng: 50px;\n        background-color: #fff;\n        border-radius: 1em;\n    }\n
    a:link, a:visited {\n        color: #38488f;\n        text-decoration: none;
\n    }\n    @media (max-width: 700px) {\n        body {\n            background
-color: #fff;\n        }\n        div {\n            width: auto;\n            m
argin: 0 auto;\n            border-radius: 0;\n            padding: 1em;\n
  }\n    }\n    </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</
h1>\n    <p>This domain is established to be used for illustrative examples in d
ocuments. You may use this\n    domain in examples without prior coordination or
 asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/exampl
e\">More information...</a></p>\n</div>\n</body>\n</html>\n"
```