### PR TITLE
Increase connection timeout for imports

### DIFF
--- a/src/Dhall/Import.hs
+++ b/src/Dhall/Import.hs
@@ -325,9 +325,9 @@ needManager = do
         Nothing -> do
             let settings = HTTP.tlsManagerSettings
 #if MIN_VERSION_http_client(0,5,0)
-                    { HTTP.managerResponseTimeout = HTTP.responseTimeoutMicro 1000000 }  -- 1 second
+                    { HTTP.managerResponseTimeout = HTTP.responseTimeoutMicro (30 * 1000 * 1000) }  -- 30 seconds
 #else
-                    { HTTP.managerResponseTimeout = Just 1000000 }  -- 1 second
+                    { HTTP.managerResponseTimeout = Just (30 * 1000 * 1000) }  -- 30 seconds
 #endif
             m <- liftIO (HTTP.newManager settings)
             zoom manager (State.put (Just m))


### PR DESCRIPTION
### TL;DR

Set the response timeout from 1s to 30s, because 1s is much too optimistic.

### Why

From time to time I have the _problem_ luck of being with a rather modest internet connection (~376Kb/s) and I noticed that even running something simple like:

```
let not = https://ipfs.io/ipfs/QmcTbCdS21pCxXysTzEiucDuwwLWbLUWNSKwkJVfwpy2zK/Prelude/Bool/not
in  not True
```

via `dhall` fails with `ConnectionTimeout`.  I saw that the connection response timeout is set to `1 second`, which is much too short for a bad internet connection. 

### How
To address this, I raised the time limit from `1 second` to `30 seconds`, because that is also the time that is used in the default `managerResponseTimeout` (https://hackage.haskell.org/package/http-client-0.5.6.1/docs/src/Network-HTTP-Client-Types.html#ManagerSettings).

With that setting I can finally use `dhall` even when I don't have a fast internet connection available. :D