### PR TITLE
Add new argument: --version

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -67,3 +67,5 @@ Executable dhall
         trifecta         >= 1.6      && < 1.7,
         text             >= 0.11.1.0 && < 1.3
     GHC-Options: -Wall
+    Other-Modules:
+        Paths_dhall

--- a/exec/Main.hs
+++ b/exec/Main.hs
@@ -7,15 +7,19 @@
 module Main where
 
 import Control.Exception (SomeException)
+import Control.Monad (when)
 import Data.Monoid (mempty)
+import Data.Version (showVersion)
 import Dhall.Core (pretty, normalize)
 import Dhall.Import (Imported(..), load)
 import Dhall.Parser (Src, exprFromText)
 import Dhall.TypeCheck (DetailedTypeError(..), TypeError)
 import Options.Generic (Generic, ParseRecord, type (<?>)(..))
 import System.IO (stderr)
-import System.Exit (exitFailure)
+import System.Exit (exitFailure, exitSuccess)
 import Text.Trifecta.Delta (Delta(..))
+
+import qualified Paths_dhall as Meta
 
 import qualified Control.Exception
 import qualified Data.Text.Lazy.IO
@@ -27,6 +31,7 @@ data Mode = Default | Resolve | TypeCheck | Normalize
 
 data Options = Options
     { explain :: Bool <?> "Explain error messages in more detail"
+    , version :: Bool <?> "Display version and exit"
     } deriving (Generic)
 
 instance ParseRecord Options
@@ -34,7 +39,9 @@ instance ParseRecord Options
 main :: IO ()
 main = do
     options <- Options.Generic.getRecord "Compiler for the Dhall language"
-
+    when (unHelpful (version options)) $ do
+      putStrLn (showVersion Meta.version)
+      exitSuccess
     let handle =
                 Control.Exception.handle handler2
             .   Control.Exception.handle handler1


### PR DESCRIPTION
Just noticed that there is no easy way to see which version of `dhall` you are using.  To remedy this, I added a new flag to the `dhall` executable, `--version` which prints it.