### PR TITLE
New builtin function: Text/length

### DIFF
--- a/Prelude/Text/length
+++ b/Prelude/Text/length
@@ -1,0 +1,13 @@
+{-
+Returns the number of chars
+
+Examples:
+
+```
+./length "foo" = +3
+./length "" = +0
+```
+-}
+let length : Text -> Natural
+    = Text/length
+in length

--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -137,6 +137,7 @@ identifierStyle = IdentifierStyle
         , "Integer"
         , "Double"
         , "Text"
+        , "Text/length"
         , "List"
         , "List/build"
         , "List/fold"
@@ -446,6 +447,7 @@ exprF embedded = choice
             ,   noted      exprF05
             ,   noted      exprF06
             ,   noted      exprF07
+            ,   noted      exprF35
             ,   noted      exprF12
             ,   noted      exprF13
             ,   noted      exprF14
@@ -605,6 +607,10 @@ exprF embedded = choice
         a <- exprA embedded
         symbol ")"
         return a
+
+    exprF35 = do
+        reserve "Text/length"
+        return TextLength
 
 const :: Parser Const
 const = const0

--- a/src/Dhall/Tutorial.hs
+++ b/src/Dhall/Tutorial.hs
@@ -107,6 +107,9 @@ module Dhall.Tutorial (
     -- *** @(++)@
     -- $textAppend
 
+    -- *** @Text/length@
+    -- $textLength
+
     -- ** @List@
     -- $list
 
@@ -1731,6 +1734,28 @@ import Dhall
 -- > x ++ "" = x
 -- > 
 -- > "" ++ x = x
+
+-- $textLength
+--
+-- Example:
+--
+-- > $ dhall
+-- > Text/length "dhall"
+-- > <Ctrl-D>
+-- > Natural
+-- >
+-- > +5
+--
+-- Type:
+--
+-- > ────────────────────────────────
+-- > Γ ⊢ Text/length : Text → Natural
+--
+-- Rules:
+--
+-- > Text/length "" = +0
+-- > Text/length (t1 ++ t2) = Text/length t1 + Text/length t2
+
 
 -- $list
 --

--- a/src/Dhall/TypeCheck.hs
+++ b/src/Dhall/TypeCheck.hs
@@ -353,6 +353,8 @@ typeWith ctx e@(TextAppend l r  ) = do
         Text -> return ()
         _    -> Left (TypeError ctx e (CantTextAppend r tr))
     return Text
+typeWith _ TextLength             = do
+    return (Pi "_" Text Natural)
 typeWith _      List              = do
     return (Pi "_" (Const Type) (Const Type))
 typeWith ctx e@(ListLit  Nothing  xs) = do


### PR DESCRIPTION
I think it would be handy to have a function that calculates the `length` of a `Text` literal.

This pr adds a new builtin function `Text/length` that does just that and is also normalized:

```
$ dhall <<< '\(x: Bool) -> Text/length "foo" + Text/length "bar" + Text/length ""'
∀(x : Bool) → Natural

λ(x : Bool) → +6
```

Take this with a grain of salt, it was more a "I would like to hack on dhall" inspired feature and not particularly driven by practical need ;)  I'm okay if you want to keep the language minimal and don't merge this.