### PR TITLE
Change tests to test source code

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -77,9 +77,10 @@ Test-Suite test
     Other-Modules:
         Normalization
     Build-Depends:
-        base             >= 4        && < 5,
-        dhall,
-        tasty            >= 0.11.2   && < 0.12,
-        tasty-hunit      >= 0.9.2    && < 0.10,
-        text             >= 0.11.1.0 && < 1.3,
-        vector           >= 0.11.0.0 && < 0.12
+        base               >= 4        && < 5   ,
+        dhall                                   ,
+        neat-interpolation >= 0.3.2.1  && < 0.4 ,
+        tasty              >= 0.11.2   && < 0.12,
+        tasty-hunit        >= 0.9.2    && < 0.10,
+        text               >= 0.11.1.0 && < 1.3 ,
+        vector             >= 0.11.0.0 && < 0.12

--- a/tests/Normalization.hs
+++ b/tests/Normalization.hs
@@ -1,11 +1,32 @@
-{-# LANGUAGE OverloadedLists #-}
-{-# LANGUAGE OverloadedStrings#-}
+{-# LANGUAGE OverloadedLists   #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+
 module Normalization (normalizationTests) where
 
+import qualified Control.Exception
+import qualified Data.Text
+import qualified Data.Text.Lazy
 import           Dhall.Core
+import           Dhall.Parser (Src)
+import qualified Dhall.Parser
+import qualified Dhall.Import
 import           Dhall.TypeCheck
+import qualified NeatInterpolation
 import           Test.Tasty
 import           Test.Tasty.HUnit
+
+code :: Data.Text.Text -> IO (Expr Src X)
+code strictText = do
+    let lazyText = Data.Text.Lazy.fromStrict strictText
+    expr0 <- case Dhall.Parser.exprFromText mempty lazyText of
+        Left parseError -> Control.Exception.throwIO parseError
+        Right expr0     -> return expr0
+    expr1 <- Dhall.Import.load expr0
+    case Dhall.TypeCheck.typeOf expr1 of
+        Left typeError -> Control.Exception.throwIO typeError
+        Right _        -> return ()
+    return expr1
 
 normalizationTests :: TestTree
 normalizationTests = testGroup "normalization" [ constantFolding
@@ -17,20 +38,20 @@ constantFolding = testGroup "folding of constants" [ naturalPlus, optionalFold, 
 
 naturalPlus :: TestTree
 naturalPlus = testCase "natural plus" $ do
+  e <- code "+1 + +2"
   isNormalized e @?= False
-  normalize' e @?= NaturalLit 3
-  where e = NaturalPlus (NaturalLit 1) (NaturalLit 2)
+  normalize' e @?= "+3"
 
 optionalFold :: TestTree
 optionalFold = testGroup "Optional/fold" [ just, nothing ]
   where test label inp out = testCase label $ do
-             isNormalized (e inp) @?= False
-             normalize' (e inp) @?= out
-        e inp = (OptionalFold `App` Text `App` OptionalLit Text inp `App`
-                                             Natural `App` (Lam "j" Text (NaturalLit 1)) `App`
-                                                 (NaturalLit 2))
-        just = test "just" [TextLit "foo"] (NaturalLit 1)
-        nothing = test "nothing" [] (NaturalLit 2)
+             e <- code [NeatInterpolation.text|
+Optional/fold Text ([$inp] : Optional Text) Natural (λ(j : Text) → +1) +2
+|]
+             isNormalized e @?= False
+             normalize' e @?= out
+        just = test "just" "\"foo\"" "+1"
+        nothing = test "nothing" "" "+2"
 
 optionalBuild :: TestTree
 optionalBuild = testGroup "Optional/build" [ optionalBuild1
@@ -40,37 +61,49 @@ optionalBuild = testGroup "Optional/build" [ optionalBuild1
 
 optionalBuild1 :: TestTree
 optionalBuild1 = testCase "reducible" $ do
+  e <- code [NeatInterpolation.text|
+Optional/build
+Natural
+(   λ(optional : Type)
+→   λ(just : Natural → optional)
+→   λ(nothing : optional)
+→   just +1
+)
+|]
   isNormalized e @?= False
-  normalize' e @?= OptionalLit Natural [NaturalLit 1]
-  where e = OptionalBuild `App` Natural `App`
-              (Lam "optional" (Const Type)
-                  (Lam "just" (Pi "_" Natural "optional")
-                      (Lam "nothing" "optional"
-                          (App "just" (NaturalLit 1)))))
+  normalize' e @?= "[+1] : Optional Natural"
 
 optionalBuildShadowing :: TestTree
 optionalBuildShadowing = testCase "handles shadowing" $ do
+  e <- code [NeatInterpolation.text|
+Optional/build
+Integer
+(   λ(optional : Type)
+→   λ(x : Integer → optional)
+→   λ(x : optional)
+→   x@1 1
+)
+|]
   isNormalized e @?= False
-  normalize' e @?= OptionalLit Integer [IntegerLit 1]
-  where e = OptionalBuild `App` Integer `App`
-                (Lam "optional" (Const Type)
-                    (Lam "x" (Pi "_" Integer "optional")
-                        (Lam "x" "optional"
-                            (App (Var (V "x" 1)) (IntegerLit 1)))))
+  normalize' e @?= "[1] : Optional Integer"
 
 optionalBuildIrreducible :: TestTree
 optionalBuildIrreducible = testCase "irreducible" $ do
+  e <- code [NeatInterpolation.text|
+    λ(id : ∀(a : Type) → a → a)
+→   Optional/build
+    Bool
+    (   λ(optional : Type)
+    →   λ(just : Bool → optional)
+    →   λ(nothing : optional)
+    →   id optional (just True)
+    )
+|]
   isNormalized e @?= True
-  normalize' e @?= e
-  where e = Lam "id" (Pi "a" (Const Type) (Pi "_" "a" "a"))
-                (OptionalBuild `App` Bool `App`
-                    (Lam "optional" (Const Type)
-                        (Lam "just" (Pi "_" Bool "optional")
-                            (Lam "nothing" "optional"
-                                ("id" `App` "optional" `App` "just" `App` BoolLit True)))))
+-- normalize e @?= e
 
-normalize' :: Expr () X -> Expr () X
-normalize' = normalize
+normalize' :: Expr Src X -> Data.Text.Lazy.Text
+normalize' = Dhall.Core.pretty . normalize
 
 fusion :: TestTree
 fusion = testGroup "Optional build/fold fusion" [ fuseOptionalBF
@@ -79,26 +112,46 @@ fusion = testGroup "Optional build/fold fusion" [ fuseOptionalBF
 
 fuseOptionalBF :: TestTree
 fuseOptionalBF = testCase "fold . build" $ do
-  isNormalized (test j) @?= False
-  normalize' (test j) @?= NaturalLit 42
-  isNormalized (test n) @?= False
-  normalize' (test n) @?= NaturalLit 2
-  where test e = OptionalFold `App` Text `App` (opt e) `App` Natural `App` (Lam "j" Text (NaturalLit 42)) `App`
-                      (NaturalLit 2)
-        opt e = OptionalBuild `App` Text `App`
-                    (Lam "optional" (Const Type)
-                        (Lam "just" (Pi "_" Text "optional")
-                            (Lam "nothing" "optional"
-                                e)))
-        j = (App "just" (TextLit "foo"))
-        n = "nothing"
+  j <- test "just \"foo\""
+  isNormalized j @?= False
+  normalize' j @?= "+42"
+  n <- test "nothing"
+  isNormalized n @?= False
+  normalize' n @?= "+2"
+  where
+    test e = code [NeatInterpolation.text|
+Optional/fold
+Text
+(   Optional/build
+    Text
+    (   λ(optional : Type)
+    →   λ(just : Text → optional)
+    →   λ(nothing : optional)
+    →   $e
+    )
+)
+Natural
+(λ(j : Text) → +42)
++2
+|]
 
 fuseOptionalFB :: TestTree
 fuseOptionalFB = testCase "build . fold" $ do
+  test <- code [NeatInterpolation.text|
+Optional/build
+Natural
+(   λ(optional : Type)
+→   λ(just : Natural → optional)
+→   λ(nothing : optional)
+→   just
+    (   Optional/fold
+        Text
+        (["foo"] : Optional Text)
+        Natural
+        (λ(just : Text) → +42)
+        +2
+    )
+)
+|]
   isNormalized test @?= False
-  normalize' test @?= OptionalLit Natural [NaturalLit 42]
-  where test = OptionalBuild `App` Natural `App`
-                   (Lam "optional" (Const Type)
-                       (Lam "just" (Pi "_" Natural "optional")
-                           (Lam "nothing" "optional" (App "just" fold))))
-        fold = OptionalFold `App` Text `App` (OptionalLit Text [TextLit "foo"]) `App` Natural `App` (Lam "just" Text (NaturalLit 42)) `App` (NaturalLit 2)
+  normalize' test @?= "[+42] : Optional Natural"


### PR DESCRIPTION
This change updates the test to test Dhall source code so that we're
exercising the system from end to end.  This also makes it easier to
author tests since expressions can be written as Dhall source code
instead of an abstract syntax tree.