### PR TITLE
Implement Natural/toInteger

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -74,8 +74,10 @@ Test-Suite test
     Type: exitcode-stdio-1.0
     Hs-Source-Dirs: tests
     Main-Is: Tests.hs
+    GHC-Options: -Wall
     Other-Modules:
         Normalization
+        Util
     Build-Depends:
         base               >= 4        && < 5   ,
         dhall                                   ,

--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -421,6 +421,7 @@ exprF embedded = choice
             ,   noted      exprF05
             ,   noted      exprF06
             ,   noted      exprF07
+            ,   noted      exprF36
             ,   noted      exprF12
             ,   noted      exprF13
             ,   noted      exprF14
@@ -477,6 +478,10 @@ exprF embedded = choice
     exprF07 = do
         reserve "Natural/odd"
         return NaturalOdd
+
+    exprF36 = do
+        reserve "Natural/toInteger"
+        return NaturalToInteger
 
     exprF08 = do
         reserve "Integer"

--- a/src/Dhall/TypeCheck.hs
+++ b/src/Dhall/TypeCheck.hs
@@ -308,6 +308,8 @@ typeWith _      NaturalEven       = do
     return (Pi "_" Natural Bool)
 typeWith _      NaturalOdd        = do
     return (Pi "_" Natural Bool)
+typeWith _      NaturalToInteger  = do
+    return (Pi "_" Natural Integer)
 typeWith ctx e@(NaturalPlus  l r) = do
     tl <- fmap Dhall.Core.normalize (typeWith ctx l)
     case tl of

--- a/tests/Normalization.hs
+++ b/tests/Normalization.hs
@@ -16,12 +16,18 @@ normalizationTests = testGroup "normalization" [ constantFolding
                                                ]
 
 constantFolding :: TestTree
-constantFolding = testGroup "folding of constants" [ naturalPlus, optionalFold, optionalBuild ]
+constantFolding = testGroup "folding of constants" [ naturalPlus, naturalToInteger, optionalFold, optionalBuild ]
 
 naturalPlus :: TestTree
 naturalPlus = testCase "natural plus" $ do
   e <- code "+1 + +2"
   e `assertNormalizesTo` "+3"
+
+naturalToInteger :: TestTree
+naturalToInteger = testCase "Natural/toInteger" $ do
+  e <- code "Natural/toInteger +1"
+  isNormalized e @?= False
+  normalize' e @?= "1"
 
 optionalFold :: TestTree
 optionalFold = testGroup "Optional/fold" [ just, nothing ]

--- a/tests/Util.hs
+++ b/tests/Util.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Util (code, normalize', assertNormalizesTo, assertNormalized) where
+
+import qualified Control.Exception
+import qualified Data.Text
+import qualified Data.Text.Lazy
+import qualified Dhall.Core
+import           Dhall.Core (Expr)
+import qualified Dhall.Import
+import qualified Dhall.Parser
+import           Dhall.Parser (Src)
+import qualified Dhall.TypeCheck
+import           Dhall.TypeCheck (X)
+import           Test.Tasty.HUnit
+
+normalize' :: Expr Src X -> Data.Text.Lazy.Text
+normalize' = Dhall.Core.pretty . Dhall.Core.normalize
+
+code :: Data.Text.Text -> IO (Expr Src X)
+code strictText = do
+    let lazyText = Data.Text.Lazy.fromStrict strictText
+    expr0 <- case Dhall.Parser.exprFromText mempty lazyText of
+        Left parseError -> Control.Exception.throwIO parseError
+        Right expr0     -> return expr0
+    expr1 <- Dhall.Import.load expr0
+    case Dhall.TypeCheck.typeOf expr1 of
+        Left typeError -> Control.Exception.throwIO typeError
+        Right _        -> return ()
+    return expr1
+
+assertNormalizesTo :: Expr Src X -> Data.Text.Lazy.Text -> IO ()
+assertNormalizesTo e expected = do
+  assertBool msg (not $ Dhall.Core.isNormalized e)
+  normalize' e @?= expected
+  where msg = "Given expression is already in normal form"
+
+assertNormalized :: Expr Src X -> IO ()
+assertNormalized e = do
+  assertBool msg1 (Dhall.Core.isNormalized e)
+  assertEqual msg2 (normalize' e) (Dhall.Core.pretty e)
+  where msg1 = "Expression was not in normal form"
+        msg2 = "Normalization is not supposed to change the expression"


### PR DESCRIPTION
As in #49 this implements the `Natural/toInteger: Natural -> Integer` conversion.

I also slightly refactored the tests to use custom assertions.

Something that is still missing: A Tutorial section on this function.  I guess it makes sense to have a whole section about `Conversions`, that lists all primitive/library conversions as `Bool -> Text`, `Natural -> Integer`, `Integer -> Text` etc.  What are your thoughts?