### PR TITLE
Forbid additional characters from paths

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,8 @@
-{ mkDerivation, ansi-wl-pprint, base, bytestring, containers
-, http-client, http-client-tls, lens, neat-interpolation
-, optparse-generic, parsers, stdenv, system-fileio, system-filepath
-, tasty, tasty-hunit, text, text-format, transformers, trifecta
-, unordered-containers, vector
+{ mkDerivation, ansi-wl-pprint, base, bytestring, charset
+, containers, http-client, http-client-tls, lens
+, neat-interpolation, optparse-generic, parsers, stdenv
+, system-fileio, system-filepath, tasty, tasty-hunit, text
+, text-format, transformers, trifecta, unordered-containers, vector
 }:
 mkDerivation {
   pname = "dhall";
@@ -11,13 +11,15 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    ansi-wl-pprint base bytestring containers http-client
+    ansi-wl-pprint base bytestring charset containers http-client
     http-client-tls lens neat-interpolation parsers system-fileio
     system-filepath text text-format transformers trifecta
     unordered-containers vector
   ];
   executableHaskellDepends = [ base optparse-generic text trifecta ];
-  testHaskellDepends = [ base tasty tasty-hunit text ];
+  testHaskellDepends = [
+    base neat-interpolation tasty tasty-hunit text vector
+  ];
   description = "A configuration language guaranteed to terminate";
   license = stdenv.lib.licenses.bsd3;
 }

--- a/dhall.cabal
+++ b/dhall.cabal
@@ -78,6 +78,7 @@ Library
         base                 >= 4.8.0.0  && < 5   ,
         ansi-wl-pprint                      < 0.7 ,
         bytestring                          < 0.11,
+        charset                             < 0.4 ,
         containers           >= 0.5.0.0  && < 0.6 ,
         http-client          >= 0.4.30   && < 0.6 ,
         http-client-tls      >= 0.2.0    && < 0.4 ,

--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -22,6 +22,7 @@ import Control.Applicative (Alternative(..), optional)
 import Control.Exception (Exception)
 import Control.Monad (MonadPlus)
 import Data.ByteString (ByteString)
+import Data.CharSet (CharSet)
 import Data.Map (Map)
 import Data.Monoid ((<>))
 import Data.Sequence (ViewL(..))
@@ -41,6 +42,7 @@ import Text.Trifecta
 import Text.Trifecta.Delta (Delta)
 
 import qualified Data.Char
+import qualified Data.CharSet
 import qualified Data.Map
 import qualified Data.ByteString.Lazy
 import qualified Data.List
@@ -739,7 +741,14 @@ import_ = do
     return (Path {..})
 
 pathChar :: Char -> Bool
-pathChar c = not (Data.Char.isSpace c || c == '(' || c == ')')
+pathChar c =
+    not
+    (   Data.Char.isSpace c
+    ||  Data.CharSet.member c disallowedPathChars
+    )
+
+disallowedPathChars :: CharSet
+disallowedPathChars = Data.CharSet.fromList "()[]{}<>:"
 
 file :: Parser PathType
 file =  try (token file0)


### PR DESCRIPTION
This reduces the number of situations where users have to end a path
with a space