### PR TITLE
Add support for string interpolation.  Fixes #47

### DIFF
--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -260,7 +260,11 @@ doubleSingleQuoteString embedded = do
         _ <- Text.Parser.Char.string "''"
         p1
 
-    p1 = p2 <|> p3 <|> p4 <|> p5 <|> p6
+    p1 =    p2
+        <|> p3
+        <|> p4 (Text.Parser.Char.char '\'')
+        <|> p5
+        <|> p4 Text.Parser.Char.anyChar
 
     p2 = do
         _  <- Text.Parser.Char.text "'''"
@@ -278,8 +282,8 @@ doubleSingleQuoteString embedded = do
         _ <- Text.Parser.Char.text "''"
         return (TextLit mempty)
 
-    p4 = do
-        s0 <- Text.Parser.Char.char '\''
+    p4 parser = do
+        s0 <- parser
         s1 <- p1
         let s4 = case s1 of
                 TextLit s2 ->
@@ -296,18 +300,6 @@ doubleSingleQuoteString embedded = do
         _  <- Text.Parser.Char.char '}'
         s3 <- p1
         return (TextAppend s1 s3)
-
-    p6 = do
-        s0 <- Text.Parser.Char.satisfy (\c -> c /= '\'' && c /= '$')
-        s1 <- p1
-        let s4 = case s1 of
-                TextLit s2 ->
-                    TextLit (build s0 <> s2)
-                TextAppend (TextLit s2) s3 ->
-                    TextAppend (TextLit (build s0 <> s2)) s3
-                _ ->
-                    TextAppend (TextLit (build s0)) s1
-        return s4
 
 lambda :: Parser ()
 lambda = symbol "\\" <|> symbol "λ"

--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -183,6 +183,7 @@ doubleQuoteLiteral embedded = do
 
     go1 = do
         _ <- Text.Parser.Char.text "${"
+        Text.Parser.Token.whiteSpace
         a <- exprA embedded
         _ <- Text.Parser.Char.char '}'
         b <- go
@@ -297,6 +298,7 @@ doubleSingleQuoteString embedded = do
 
     p5 = do
         _  <- Text.Parser.Char.text "${"
+        Text.Parser.Token.whiteSpace
         s1 <- exprA embedded
         _  <- Text.Parser.Char.char '}'
         s3 <- p1

--- a/src/Dhall/Tutorial.hs
+++ b/src/Dhall/Tutorial.hs
@@ -762,7 +762,28 @@ import Dhall
 -- minimal indentation of the string as a whole (disregarding the indentation
 -- of empty lines).\"
 --
--- Unlike Nix-style strings, you cannot interpolate variables into the string.
+-- You can also interpolate expressions into strings using @${...}@ syntax.  For
+-- example:
+--
+-- > $ dhall
+-- >     let name = "John Doe"
+-- > in  let age  = 21
+-- > in  "My name is ${name} and my age is ${Integer/show age}"
+-- > <Ctrl-D>
+-- > Text
+-- >
+-- > "My name is John Doe and my age is 21"
+--
+-- Note that you can only interpolate expressions of type @Text@
+--
+-- If you need to insert a @"${"@ into a string without interpolation then use
+-- @"'${"@ (same as Nix)
+--
+-- > ''
+-- >     for file in *; do
+-- >       echo "Found '${file}"
+-- >     done
+-- > ''
 
 -- $combine
 --

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -2,6 +2,7 @@ module Main where
 
 import Normalization (normalizationTests)
 import Examples (exampleTests)
+import Tutorial (tutorialTests)
 import Test.Tasty
 
 allTests :: TestTree
@@ -9,6 +10,7 @@ allTests =
     testGroup "Dhall Tests"
         [ normalizationTests
         , exampleTests
+        , tutorialTests
         ]
 
 main :: IO ()

--- a/tests/Tutorial.hs
+++ b/tests/Tutorial.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+
+module Tutorial where
+
+import qualified NeatInterpolation
+import qualified Test.Tasty
+import qualified Test.Tasty.HUnit
+import qualified Util
+
+import Test.Tasty (TestTree)
+
+tutorialTests :: TestTree
+tutorialTests =
+    Test.Tasty.testGroup "tutorial"
+        [ Test.Tasty.testGroup "Interpolation"
+            [ _Interpolation_0
+            , _Interpolation_1
+            ]
+        ]
+
+_Interpolation_0 :: TestTree
+_Interpolation_0 = Test.Tasty.HUnit.testCase "Example #0" (do
+    e <- Util.code [NeatInterpolation.text|
+    let name = "John Doe"
+in  let age  = 21
+in  "My name is $${name} and my age is $${Integer/show age}"
+|]
+    Util.assertNormalizesTo e "\"My name is John Doe and my age is 21\"" )
+
+_Interpolation_1 :: TestTree
+_Interpolation_1 = Test.Tasty.HUnit.testCase "Example #0" (do
+    e <- Util.code [NeatInterpolation.text|
+''
+    for file in *; do
+      echo "Found '$${file}"
+    done
+''
+|]
+    Util.assertNormalized e )


### PR DESCRIPTION
You can now interpolate any expression of type `Text` into a string literal,
like this:

```haskell
let renderRating
    =   λ(rating : { name : Text, rating : Natural })
    →   let score = Integer/show (Natural/toInteger rating.rating)
    in  ''
        # My thoughts about ${rating.name} (${score} out of 5)
        ''
in  renderRating { name = "Dhall", rating = +6 }
```