### PR TITLE
Fix escaping rules for `${` to match Nix

### DIFF
--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -190,7 +190,7 @@ doubleQuoteLiteral embedded = do
         return (TextAppend a b)
 
     go2 = do
-        _ <- Text.Parser.Char.text "'${"
+        _ <- Text.Parser.Char.text "''${"
         b <- go
         let e = case b of
                 TextLit cs ->
@@ -292,7 +292,7 @@ doubleSingleQuoteString embedded = do
         return s4
 
     p3 = do
-        _  <- Text.Parser.Char.text "'${"
+        _  <- Text.Parser.Char.text "''${"
         s1 <- p1
         let s4 = case s1 of
                 TextLit s2 ->

--- a/src/Dhall/Tutorial.hs
+++ b/src/Dhall/Tutorial.hs
@@ -777,11 +777,11 @@ import Dhall
 -- Note that you can only interpolate expressions of type @Text@
 --
 -- If you need to insert a @"${"@ into a string without interpolation then use
--- @"'${"@ (same as Nix)
+-- @"''${"@ (same as Nix)
 --
 -- > ''
 -- >     for file in *; do
--- >       echo "Found '${file}"
+-- >       echo "Found ''${file}"
 -- >     done
 -- > ''
 

--- a/tests/Tutorial.hs
+++ b/tests/Tutorial.hs
@@ -33,7 +33,7 @@ _Interpolation_1 = Test.Tasty.HUnit.testCase "Example #0" (do
     e <- Util.code [NeatInterpolation.text|
 ''
     for file in *; do
-      echo "Found '$${file}"
+      echo "Found ''$${file}"
     done
 ''
 |]


### PR DESCRIPTION
Nix actually uses two single quotes to escape `${` instead of one single quote