### PR TITLE
Add `Prelude/Text/intercalate`

### DIFF
--- a/Prelude/Text/intercalate
+++ b/Prelude/Text/intercalate
@@ -1,0 +1,43 @@
+{-
+Combine a `List` of `Text` values with a separator in between each value
+
+Examples:
+
+```
+./intercalate ", " ["ABC", "DEF", "GHI"] = "ABC, DEF, GHI"
+
+./intercalate ", " ([] : List Text) = ""
+```
+-}
+let intercalate : ∀(separator : Text) → ∀(elements : List Text) → Text
+    =   λ(separator : Text)
+    →   λ(elements : List Text)
+    →   let status
+            =   List/fold
+                Text
+                elements
+                < Empty : {} | NonEmpty : Text >
+                (   λ(element : Text)
+                →   λ(status : < Empty : {} | NonEmpty : Text >)
+                →   merge
+                    {   Empty
+                        =   λ(_ : {})
+                        →   < NonEmpty = element
+                            | Empty : {}
+                            >
+                    ,   NonEmpty
+                        =   λ(result : Text)
+                        →   < NonEmpty = element ++ separator ++ result
+                            | Empty : {}
+                            >
+                    }
+                    status : < Empty : {} | NonEmpty : Text >
+                )
+                < Empty = {=} | NonEmpty : Text >
+    in  merge
+        { Empty    = λ(_ : {}) → ""
+        , NonEmpty = λ(result : Text) → result
+        }
+        status : Text
+
+in  intercalate

--- a/tests/Examples.hs
+++ b/tests/Examples.hs
@@ -236,6 +236,10 @@ exampleTests =
                 [ _Text_concat_0
                 , _Text_concat_1
                 ]
+            , Test.Tasty.testGroup "intercalate"
+                [ _Text_intercalate_0
+                , _Text_intercalate_1
+                ]
             ]
         ]
 
@@ -1132,5 +1136,19 @@ _Text_concat_1 :: TestTree
 _Text_concat_1 = Test.Tasty.HUnit.testCase "Example #1" (do
     e <- Util.code [NeatInterpolation.text|
 ./Prelude/Text/concat ([] : List Text)
+|]
+    Util.assertNormalizesTo e "\"\"" )
+
+_Text_intercalate_0 :: TestTree
+_Text_intercalate_0 = Test.Tasty.HUnit.testCase "Example #0" (do
+    e <- Util.code [NeatInterpolation.text|
+./Prelude/Text/intercalate ", " ["ABC", "DEF", "GHI"]
+|]
+    Util.assertNormalizesTo e "\"ABC, DEF, GHI\"" )
+
+_Text_intercalate_1 :: TestTree
+_Text_intercalate_1 = Test.Tasty.HUnit.testCase "Example #1" (do
+    e <- Util.code [NeatInterpolation.text|
+./Prelude/Text/intercalate ", " ([] : List Text)
 |]
     Util.assertNormalizesTo e "\"\"" )


### PR DESCRIPTION
Interspersing a separator in between string elements is sufficiently
tricky that there should be a utility to do this