### PR TITLE
Make `merge` type annotation optional

### DIFF
--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -431,8 +431,9 @@ exprB embedded = choice
         reserve "merge"
         a <- exprE embedded
         b <- exprE embedded
-        symbol ":"
-        c <- exprD embedded
+        c <- optional (do
+            symbol ":"
+            exprD embedded )
         return (Merge a b c)
 
     exprB1 = do

--- a/src/Dhall/Tutorial.hs
+++ b/src/Dhall/Tutorial.hs
@@ -1036,6 +1036,11 @@ import Dhall
 -- Notice that each handler has to return the same type of result (@Bool@ in
 -- this case) which must also match the declared result type of the @merge@.
 --
+-- You can also omit the type annotation when merging a union with one or more
+-- alternatives, like this:
+--
+-- > merge { Left = Natural/even, Right = λ(b : Bool) → b } < Right = True | Left : Natural >
+--
 -- __Exercise__: Create a list of the following type with at least one element
 -- per alternative:
 --


### PR DESCRIPTION
You can now omit the type annotation on `merge`s so long as the union
being merged has at least one alternative