### PR TITLE
Relax bound on trifecta for GHC 8.2

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -95,7 +95,7 @@ Library
         text                 >= 0.11.1.0 && < 1.3 ,
         text-format                         < 0.4 ,
         transformers         >= 0.2.0.0  && < 0.6 ,
-        trifecta             >= 1.6      && < 1.7 ,
+        trifecta             >= 1.6      && < 1.8 ,
         unordered-containers >= 0.1.3.0  && < 0.3 ,
         vector               >= 0.11.0.0 && < 0.13
     Exposed-Modules:
@@ -115,7 +115,7 @@ Executable dhall
         base             >= 4        && < 5  ,
         dhall                                ,
         optparse-generic >= 1.1.1    && < 1.2,
-        trifecta         >= 1.6      && < 1.7,
+        trifecta         >= 1.6      && < 1.8,
         text             >= 0.11.1.0 && < 1.3
     GHC-Options: -Wall
     Other-Modules:


### PR DESCRIPTION
trifecta-1.7 is the first version of trifecta
that builds with GHC 8.2 and Cabal 2.0

FWIW the testsuite still passes.