### PR TITLE
Fix import bug when canonicalizing paths with home directories

### DIFF
--- a/src/Dhall/Import.hs
+++ b/src/Dhall/Import.hs
@@ -390,7 +390,7 @@ canonicalize (File hasHome0 file0:paths0) =
     go currPath (File hasHome file:paths) =
         if Filesystem.relative file && hasHome == Homeless
         then go file' paths
-        else File hasHome0 (clean file')
+        else File hasHome (clean file')
       where
         file' = Filesystem.parent (removeAtFromFile file) </> currPath
 canonicalize (URL path:_) = URL path


### PR DESCRIPTION
Before this change, if you saved the following files:

```bash
$ echo "~/bar" > /tmp/foo
$ echo "./baz" > ~/bar
$ echo "1"     > ~/baz
```

... then you would get the following error:

```bash
$ dhall <<< '/tmp/foo'

↳ ./foo
  ↳ ~/.bar
    ↳ ./baz

Error: Missing file
```

This is because path canonicalization had a bug where relative directories like
`./baz` do not get correctly resolved relative to home-anchored directories like
`~/.bar`.  The compiler instead mistakenly tried to locate a non-home-anchored
`./baz` file, which does not exist.

After this fix, the above code resolves correctly tries to resolve `~/baz` as
the last file in the import chain and succeeds with:

```bash
$ dhall <<< '/tmp/foo'
Integer

1
```