### PR TITLE
Rename `intercalate` to `concatSep`

### DIFF
--- a/Prelude/Text/concatSep
+++ b/Prelude/Text/concatSep
@@ -1,15 +1,15 @@
 {-
-Combine a `List` of `Text` values with a separator in between each value
+Concatenate a `List` of `Text` values with a separator in between each value
 
 Examples:
 
 ```
-./intercalate ", " ["ABC", "DEF", "GHI"] = "ABC, DEF, GHI"
+./concatSep ", " ["ABC", "DEF", "GHI"] = "ABC, DEF, GHI"
 
-./intercalate ", " ([] : List Text) = ""
+./concatSep ", " ([] : List Text) = ""
 ```
 -}
-let intercalate : ∀(separator : Text) → ∀(elements : List Text) → Text
+let concatSep : ∀(separator : Text) → ∀(elements : List Text) → Text
     =   λ(separator : Text)
     →   λ(elements : List Text)
     →   let status
@@ -40,4 +40,4 @@ let intercalate : ∀(separator : Text) → ∀(elements : List Text) → Text
         }
         status : Text
 
-in  intercalate
+in  concatSep

--- a/tests/Examples.hs
+++ b/tests/Examples.hs
@@ -236,9 +236,9 @@ exampleTests =
                 [ _Text_concat_0
                 , _Text_concat_1
                 ]
-            , Test.Tasty.testGroup "intercalate"
-                [ _Text_intercalate_0
-                , _Text_intercalate_1
+            , Test.Tasty.testGroup "concatSep"
+                [ _Text_concatSep_0
+                , _Text_concatSep_1
                 ]
             ]
         ]
@@ -1139,16 +1139,16 @@ _Text_concat_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 |]
     Util.assertNormalizesTo e "\"\"" )
 
-_Text_intercalate_0 :: TestTree
-_Text_intercalate_0 = Test.Tasty.HUnit.testCase "Example #0" (do
+_Text_concatSep_0 :: TestTree
+_Text_concatSep_0 = Test.Tasty.HUnit.testCase "Example #0" (do
     e <- Util.code [NeatInterpolation.text|
-./Prelude/Text/intercalate ", " ["ABC", "DEF", "GHI"]
+./Prelude/Text/concatSep ", " ["ABC", "DEF", "GHI"]
 |]
     Util.assertNormalizesTo e "\"ABC, DEF, GHI\"" )
 
-_Text_intercalate_1 :: TestTree
-_Text_intercalate_1 = Test.Tasty.HUnit.testCase "Example #1" (do
+_Text_concatSep_1 :: TestTree
+_Text_concatSep_1 = Test.Tasty.HUnit.testCase "Example #1" (do
     e <- Util.code [NeatInterpolation.text|
-./Prelude/Text/intercalate ", " ([] : List Text)
+./Prelude/Text/concatSep ", " ([] : List Text)
 |]
     Util.assertNormalizesTo e "\"\"" )


### PR DESCRIPTION
This uses Nix's naming convention for consistency