### PR TITLE
Added `normalizeWith` function.

### DIFF
--- a/tests/Normalization.hs
+++ b/tests/Normalization.hs
@@ -34,7 +34,7 @@ conversions = testGroup "conversions" [ naturalShow
 customization :: TestTree
 customization = testGroup "customization"
                  [simpleCustomization
-                 ,doubleReduction]
+                 ,nestedReduction]
 
 simpleCustomization :: TestTree
 simpleCustomization = testCase "simpleCustomization" $ do
@@ -45,12 +45,12 @@ simpleCustomization = testCase "simpleCustomization" $ do
   e <- codeWith tyCtx "min (min +11 +12) +8 + +1" 
   assertNormalizesToWith valCtx e "+9"
 
-doubleReduction :: TestTree
-doubleReduction = testCase "doubleReduction" $ do
-  let tyCtx  =  insert "min" (Pi "_" Natural (Pi "_" Natural Natural)) 
-               . insert "fiveorless" (Pi "_" Natural Natural)
-               . insert "wurble" (Pi "_" Natural Integer)
-               $ empty 
+nestedReduction :: TestTree
+nestedReduction = testCase "doubleReduction" $ do
+  minType        <- insert "min"        <$> code "Natural → Natural → Natural"
+  fiveorlessType <- insert "fiveorless" <$> code "Natural → Natural"
+  wurbleType     <- insert "wurble"     <$> code "Natural → Integer"
+  let tyCtx = minType . fiveorlessType . wurbleType $ empty
       valCtx e = case e of
                     (App (App (Var (V "min" 0)) (NaturalLit x)) (NaturalLit y)) -> Just (NaturalLit (min x y))
                     (App (Var (V "wurble" 0)) (NaturalLit x)) -> Just

--- a/tests/Normalization.hs
+++ b/tests/Normalization.hs
@@ -5,15 +5,17 @@
 module Normalization (normalizationTests) where
 
 import           Dhall.Core
+import           Dhall.Context
 import qualified NeatInterpolation
 import           Test.Tasty
 import           Test.Tasty.HUnit
-import           Util (code, normalize', assertNormalizesTo, assertNormalized)
+import           Util 
 
 normalizationTests :: TestTree
 normalizationTests = testGroup "normalization" [ constantFolding
                                                , conversions
                                                , fusion
+                                               , customization
                                                ]
 
 constantFolding :: TestTree
@@ -28,6 +30,36 @@ conversions = testGroup "conversions" [ naturalShow
                                       , doubleShow
                                       , naturalToInteger
                                       ]
+
+customization :: TestTree
+customization = testGroup "customization"
+                 [simpleCustomization
+                 ,doubleReduction]
+
+simpleCustomization :: TestTree
+simpleCustomization = testCase "simpleCustomization" $ do
+  let tyCtx  = insert "min" (Pi "_" Natural (Pi "_" Natural Natural)) empty 
+      valCtx e = case e of
+                    (App (App (Var (V "min" 0)) (NaturalLit x)) (NaturalLit y)) -> Just (NaturalLit (min x y))
+                    _ -> Nothing
+  e <- codeWith tyCtx "min (min +11 +12) +8 + +1" 
+  assertNormalizesToWith valCtx e "+9"
+
+doubleReduction :: TestTree
+doubleReduction = testCase "doubleReduction" $ do
+  let tyCtx  =  insert "min" (Pi "_" Natural (Pi "_" Natural Natural)) 
+               . insert "fiveorless" (Pi "_" Natural Natural)
+               . insert "wurble" (Pi "_" Natural Integer)
+               $ empty 
+      valCtx e = case e of
+                    (App (App (Var (V "min" 0)) (NaturalLit x)) (NaturalLit y)) -> Just (NaturalLit (min x y))
+                    (App (Var (V "wurble" 0)) (NaturalLit x)) -> Just
+                        (App (Var (V "fiveorless" 0)) (NaturalPlus (NaturalLit x) (NaturalLit 2))) 
+                    (App (Var (V "fiveorless" 0)) (NaturalLit x)) -> Just
+                        (App (App (Var (V "min" 0)) (NaturalLit x)) (NaturalPlus (NaturalLit 3) (NaturalLit 2)))
+                    _ -> Nothing
+  e <- codeWith tyCtx "wurble +6"
+  assertNormalizesToWith valCtx e "+5"
 
 naturalPlus :: TestTree
 naturalPlus = testCase "natural plus" $ do

--- a/tests/Util.hs
+++ b/tests/Util.hs
@@ -18,7 +18,7 @@ import           Data.Bifunctor (first)
 import           Data.Text (Text)
 import qualified Data.Text.Lazy
 import qualified Dhall.Core
-import           Dhall.Core (Expr, CtxFun)
+import           Dhall.Core (Expr, Normalizer)
 import qualified Dhall.Context
 import           Dhall.Context (Context)
 import qualified Dhall.Import
@@ -31,7 +31,7 @@ import           Test.Tasty.HUnit
 normalize' :: Expr Src X -> Data.Text.Lazy.Text
 normalize' = Dhall.Core.pretty . Dhall.Core.normalize
 
-normalizeWith' :: CtxFun X -> Expr Src X -> Data.Text.Lazy.Text
+normalizeWith' :: Normalizer X -> Expr Src X -> Data.Text.Lazy.Text
 normalizeWith' ctx = Dhall.Core.pretty . Dhall.Core.normalizeWith ctx
 
 code :: Data.Text.Text -> IO (Expr Src X)
@@ -55,7 +55,7 @@ assertNormalizesTo e expected = do
   normalize' e @?= expected
   where msg = "Given expression is already in normal form"
 
-assertNormalizesToWith :: CtxFun X -> Expr Src X -> Data.Text.Lazy.Text -> IO ()
+assertNormalizesToWith :: Normalizer X -> Expr Src X -> Data.Text.Lazy.Text -> IO ()
 assertNormalizesToWith ctx e expected = do
   assertBool msg (not $ Dhall.Core.isNormalizedWith ctx (first (const ()) e))
   normalizeWith' ctx e @?= expected

--- a/tests/Util.hs
+++ b/tests/Util.hs
@@ -1,19 +1,26 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 module Util
     ( code
+    , codeWith
     , normalize'
+    , normalizeWith'
     , assertNormalizesTo
+    , assertNormalizesToWith
     , assertNormalized
     , assertTypeChecks
     ) where
 
 import qualified Control.Exception
 import qualified Data.Functor
+import           Data.Bifunctor (first)
 import           Data.Text (Text)
 import qualified Data.Text.Lazy
 import qualified Dhall.Core
-import           Dhall.Core (Expr)
+import           Dhall.Core (Expr, CtxFun)
+import qualified Dhall.Context
+import           Dhall.Context (Context)
 import qualified Dhall.Import
 import qualified Dhall.Parser
 import           Dhall.Parser (Src)
@@ -24,22 +31,34 @@ import           Test.Tasty.HUnit
 normalize' :: Expr Src X -> Data.Text.Lazy.Text
 normalize' = Dhall.Core.pretty . Dhall.Core.normalize
 
+normalizeWith' :: CtxFun X -> Expr Src X -> Data.Text.Lazy.Text
+normalizeWith' ctx = Dhall.Core.pretty . Dhall.Core.normalizeWith ctx
+
 code :: Data.Text.Text -> IO (Expr Src X)
-code strictText = do
+code = codeWith Dhall.Context.empty
+
+codeWith :: Context (Expr Src X) -> Data.Text.Text -> IO (Expr Src X)
+codeWith ctx strictText = do
     let lazyText = Data.Text.Lazy.fromStrict strictText
     expr0 <- case Dhall.Parser.exprFromText mempty lazyText of
         Left parseError -> Control.Exception.throwIO parseError
         Right expr0     -> return expr0
     expr1 <- Dhall.Import.load expr0
-    case Dhall.TypeCheck.typeOf expr1 of
+    case Dhall.TypeCheck.typeWith ctx expr1 of
         Left typeError -> Control.Exception.throwIO typeError
         Right _        -> return ()
     return expr1
 
 assertNormalizesTo :: Expr Src X -> Data.Text.Lazy.Text -> IO ()
-assertNormalizesTo e expected = do
+assertNormalizesTo e expected = do 
   assertBool msg (not $ Dhall.Core.isNormalized e)
   normalize' e @?= expected
+  where msg = "Given expression is already in normal form"
+
+assertNormalizesToWith :: CtxFun X -> Expr Src X -> Data.Text.Lazy.Text -> IO ()
+assertNormalizesToWith ctx e expected = do
+  assertBool msg (not $ Dhall.Core.isNormalizedWith ctx (first (const ()) e))
+  normalizeWith' ctx e @?= expected
   where msg = "Given expression is already in normal form"
 
 assertNormalized :: Expr Src X -> IO ()


### PR DESCRIPTION
Added `normalizeWith` function to complement `typeWith`.
Dhall is so very attractive base for simple DSLs that I felt it
needed to be pushed over the edge.

Naturally, using `normalizeWith` loses all the nice features of Dhall.
If your context isn't total or strongly normalizing then embedding it
to Dhall will not improve things.

I didn't spend too much time testing the change since I have some doubts whether this is an acceptable regarding the original mission of Dhall.
