### PR TITLE
Raw input

### DIFF
--- a/src/Dhall.hs
+++ b/src/Dhall.hs
@@ -16,7 +16,6 @@ module Dhall
     (
     -- * Input
       input
-    , rawInput
     , detailed
 
     -- * Types
@@ -34,6 +33,8 @@ module Dhall
     , maybe
     , vector
     , GenericInterpret(..)
+    -- * Miscellaneous
+    , rawInput
 
     -- * Re-exports
     , Natural


### PR DESCRIPTION
Working with `normalizeWith` (see #79) seems to necessitate converting Dhall values to Haskell quite often. However, the existing machinery for this (ie. `input`) is not adequate to the task, since it works with `Text` instead of `Expr`'s.

I would made a new module like `Dhall.Customization` for this function, but that would have required restructuring the `Dhall` module or exposing the `Type` type. Having this in `Dhall` may just confuse new users...