### PR TITLE
Export InputType

### DIFF
--- a/src/Dhall.hs
+++ b/src/Dhall.hs
@@ -19,6 +19,7 @@ module Dhall
 
     -- * Types
     , Type(..)
+    , InputType(..)
     , Interpret(..)
     , InvalidType(..)
     , auto


### PR DESCRIPTION
Apparently this export was forgotten. Hopefully the intention was to fully export `InputType`.

IMHO the reasons for full export are:

* Symmetry with the already exported `Type` :)
* It allows to pass Haskell values through the `normalizeWith`