### PR TITLE
Ability to load expressions purely.

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -95,6 +95,7 @@ Library
         charset                             < 0.4 ,
         containers           >= 0.5.0.0  && < 0.6 ,
         contravariant                       < 1.5 ,
+        exceptions           >= 0.8.3    && < 0.9 ,
         http-client          >= 0.4.30   && < 0.6 ,
         http-client-tls      >= 0.2.0    && < 0.4 ,
         lens                 >= 2.4      && < 4.16,


### PR DESCRIPTION
* Refactor `loadStaticWith` to work in `MonadCatch` monad
using `exprFromPath` as a callback.

* Add `load'`, `loadWith'` functions to allow resolving
Path expressions using callback in any `MonadCatch` monad.

* Consolidate `StateT Status` evaluation into internal `evalStatus`
function.

As proposed in https://github.com/Gabriel439/Haskell-Dhall-Library/issues/92.