### PR TITLE
Add Eq instance for Src

### DIFF
--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -60,7 +60,7 @@ import qualified Text.PrettyPrint.ANSI.Leijen
 import qualified Text.Trifecta
 
 -- | Source code extract
-data Src = Src Delta Delta ByteString deriving (Show)
+data Src = Src Delta Delta ByteString deriving (Eq, Show)
 
 instance Buildable Src where
     build (Src begin _ bytes) =


### PR DESCRIPTION
It is convenient to check equality of `Expr Src X` sometimes.