### PR TITLE
Interpret instance for unnamed data fields

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -144,6 +144,7 @@ Test-Suite test
         Util
     Build-Depends:
         base               >= 4        && < 5   ,
+        containers         >= 0.5.0.0  && < 0.6 ,
         dhall                                   ,
         tasty              >= 0.11.2   && < 0.12,
         tasty-hunit        >= 0.9.2    && < 0.10,

--- a/tests/Regression.hs
+++ b/tests/Regression.hs
@@ -1,7 +1,13 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Regression where
 
+import qualified Data.Map
+import qualified Dhall
+import qualified Dhall.Core
 import qualified Test.Tasty
 import qualified Test.Tasty.HUnit
 import qualified Util
@@ -12,7 +18,24 @@ regressionTests :: TestTree
 regressionTests =
     Test.Tasty.testGroup "regression tests"
         [ issue96
+          , unnamedFields
         ]
+
+data Foo = Foo Integer Bool | Bar Bool Bool Bool | Baz Integer Integer
+    deriving (Show, Dhall.Generic, Dhall.Interpret)
+
+unnamedFields :: TestTree
+unnamedFields = Test.Tasty.HUnit.testCase "Unnamed Fields" (do
+    let ty = Dhall.auto @Foo
+    Test.Tasty.HUnit.assertEqual "Good type" (Dhall.expected ty) (Dhall.Core.Union (
+            Data.Map.fromList [
+                ("Bar",Dhall.Core.Record (Data.Map.fromList [
+                    ("_1",Dhall.Core.Bool),("_2",Dhall.Core.Bool),("_3",Dhall.Core.Bool)]))
+                , ("Baz",Dhall.Core.Record (Data.Map.fromList [
+                    ("_1",Dhall.Core.Integer),("_2",Dhall.Core.Integer)]))
+                ,("Foo",Dhall.Core.Record (Data.Map.fromList [
+                    ("_1",Dhall.Core.Integer),("_2",Dhall.Core.Bool)]))]))
+    return () )
 
 issue96 :: TestTree
 issue96 = Test.Tasty.HUnit.testCase "Issue #96" (do


### PR DESCRIPTION
Maps unnamed data fields to the positional record keys. For example:

`data Foo = Foo Bool Integer Natural deriving (Generic, Interpret)`

is mapped to:

`Record { _1 : Bool, _2 : Integer, _3 : Natural }`

Dhall data type.