### PR TITLE
Drop support for GHC 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.22 GHCVER=7.10.2
-      compiler: ": #GHC 7.10.2"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.1
       compiler: ": #GHC 8.0.1"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}}
@@ -38,7 +35,7 @@ install:
  - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
 
 # check whether current requested install-plan matches cached package-db snapshot
- - if diff -u installplan.txt $HOME/.cabsnap/installplan.txt;
+ - if diff -u $HOME/.cabsnap/installplan.txt installplan.txt;
    then
      echo "cabal build-cache HIT";
      rm -rfv .ghc;

--- a/dhall.cabal
+++ b/dhall.cabal
@@ -2,7 +2,7 @@ Name: dhall
 Version: 1.5.1
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
-Tested-With: GHC == 7.10.2, GHC == 8.0.1
+Tested-With: GHC == 8.0.1
 License: BSD3
 License-File: LICENSE
 Copyright: 2017 Gabriel Gonzalez


### PR DESCRIPTION
The main motivation for this change is to take advantage of new features in
GHC 8.  Dropping support for GHC 7 seems reasonable given that even Debian
stable is on GHC 8