### PR TITLE
Minor simplification to `token`

### DIFF
--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -102,10 +102,7 @@ instance TokenParsing Parser where
 
     highlight h (Parser m) = Parser (highlight h m)
 
-    token parser = do
-        r <- parser
-        Text.Parser.Token.whiteSpace
-        return r
+    token parser = Parser (token (unParser parser))
 
 identifierStyle :: IdentifierStyle Parser
 identifierStyle = IdentifierStyle


### PR DESCRIPTION
The implementation of `token` for `Parser` is identical to the one for
`Text.Trifecta.Parser`, so we can simplify the implementation as just
unwrapping and wrapping the newtypes