### PR TITLE
Fix unnecessary partial function

### DIFF
--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -46,7 +46,6 @@ import qualified Data.Map
 import qualified Data.ByteString.Lazy
 import qualified Data.List
 import qualified Data.Sequence
-import qualified Data.Text
 import qualified Data.Text.Lazy
 import qualified Data.Text.Lazy.Builder
 import qualified Data.Text.Lazy.Encoding
@@ -514,8 +513,7 @@ exprD embedded = do
     es <- many (noted (try (exprE embedded)))
     let app nL@(Note (Src before _ bytesL) _) nR@(Note (Src _ after bytesR) _) =
             Note (Src before after (bytesL <> bytesR)) (App nL nR)
-        app _ _ = Dhall.Core.internalError
-            ("Dhall.Parser.exprD: foldl1 app (" <> Data.Text.pack (show es) <> ")")
+        app nL nR = App nL nR
     return (Data.List.foldl1 app (e:es))
 
 exprE :: Show a => Parser a -> Parser (Expr Src a)


### PR DESCRIPTION
I ran into this inexhaustive pattern match when testing changes to the parser
(mainly due to replacing `noted` with `id`)

There's a safe and obvious way to handle the fallback case, and I'm not really
sure why I made the function partial in the first place