### PR TITLE
Remove unnecessary `token`

### DIFF
--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -215,7 +215,7 @@ doubleQuoteLiteral embedded = do
 
 doubleSingleQuoteString :: Show a => Parser a -> Parser (Expr Src a)
 doubleSingleQuoteString embedded = do
-    expr0 <- Text.Parser.Token.token p0
+    expr0 <- p0
 
     let builder0      = concatFragments expr0
     let text0         = Data.Text.Lazy.Builder.toLazyText builder0

--- a/tests/Regression.hs
+++ b/tests/Regression.hs
@@ -18,7 +18,8 @@ regressionTests :: TestTree
 regressionTests =
     Test.Tasty.testGroup "regression tests"
         [ issue96
-          , unnamedFields
+        , unnamedFields
+        , trailingSpaceAfterStringLiterals
         ]
 
 data Foo = Foo Integer Bool | Bar Bool Bool Bool | Baz Integer Integer
@@ -53,3 +54,11 @@ issue96 = Test.Tasty.HUnit.testCase "Issue #96" (do
     -- Verify that parsing should not fail
     _ <- Util.code "\"bar'baz\""
     return () )
+
+trailingSpaceAfterStringLiterals :: TestTree
+trailingSpaceAfterStringLiterals =
+    Test.Tasty.HUnit.testCase "Trailing space after string literals" (do
+        -- Verify that string literals parse correctly with trailing space
+        -- (Yes, I did get this wrong at some point)
+        _ <- Util.code "(''ABC'' ++ \"DEF\" )"
+        return () )


### PR DESCRIPTION
The `doubleSingleQuoteLiteral` parser doesn't need `token` to parse
trailing whitespace because the `stringLiteral` parser is already
surrounded by a `token`