### PR TITLE
Increase lower bound on `base`

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -89,7 +89,7 @@ Source-Repository head
 Library
     Hs-Source-Dirs: src
     Build-Depends:
-        base                 >= 4.8.0.0  && < 5   ,
+        base                 >= 4.9.0.0  && < 5   ,
         ansi-wl-pprint                      < 0.7 ,
         bytestring                          < 0.11,
         case-insensitive                    < 1.3 ,


### PR DESCRIPTION
This change signals that we don't intend to build against versions of
`ghc` earlier than `ghc-8.0.1` any longer.  `base-4.9.0.0` is the
version that shipped with `ghc-8.0.1`