### PR TITLE
Fix comment parsing

### DIFF
--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -101,8 +101,6 @@ instance TokenParsing Parser where
 
     highlight h (Parser m) = Parser (highlight h m)
 
-    token parser = Parser (token (unParser parser))
-
 identifierStyle :: IdentifierStyle Parser
 identifierStyle = IdentifierStyle
     { _styleName     = "dhall"


### PR DESCRIPTION
Fixes #117 

I broke comment parsing in 52d097eba3ffb820ce7e86d0fe2655437ef0915c due to
accidentally changing how `token` behaves.  What was supposed to be a
behavior-preserving simplification actually broke parsing of comments within
the internal whitespace of an expression

The root of the problem was that `token` used to correctly use the `whitespace`
parser for `Dhall.Parser.Parser`, which correctly parses comments, but after
the breaking change `token` would defer to the behavior of `whitespace` for
`Text.Trifecta.Parser`, which does not support parsing comments

The correct simplification is to omit the definition of `token` altogether,
because the default implementation matches the correct implementation.  This
change updates `token` to default to the right implementation