### PR TITLE
Improve parsing performance

### DIFF
--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -811,28 +811,22 @@ alternativeType embedded = do
     return (a, b)
 
 unionLit :: Show a => Parser a -> Parser (Expr Src a)
-unionLit embedded =
-        try unionLit0
-    <|>     unionLit1
-  where
-    unionLit0 = do
-        symbol "<"
-        a <- label
-        symbol "="
-        b <- exprA embedded
-        symbol ">"
-        return (UnionLit a b Data.Map.empty)
+unionLit embedded = do
+    symbol "<"
+    a <- label
+    symbol "="
+    b <- exprA embedded
+    let unionLit0 = do
+            symbol ">"
+            return (UnionLit a b Data.Map.empty)
 
-    unionLit1 = do
-        symbol "<"
-        a <- label
-        symbol "="
-        b <- exprA embedded
-        symbol "|"
-        c <- alternativeTypes embedded
-        d <- toMap c
-        symbol ">"
-        return (UnionLit a b d)
+    let unionLit1 = do
+            symbol "|"
+            c <- alternativeTypes embedded
+            d <- toMap c
+            symbol ">"
+            return (UnionLit a b d)
+    unionLit0 <|> unionLit1
 
 listLit :: Show a => Parser a -> Parser (Expr Src a)
 listLit embedded = do


### PR DESCRIPTION
This left-factors the parser for union literals to remove an unnecessary
`try`.  This in turn improves the throughput of `dhall` on the slow
example described in #108 by 56% (2.290 s → 1.465 s)